### PR TITLE
Ensure that saveFormat is saved as a string for every property editor

### DIFF
--- a/source/nuPickers/DataEditors/DotNetCheckBoxPicker/DotNetCheckBoxPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/DotNetCheckBoxPicker/DotNetCheckBoxPickerConfiguration.cs
@@ -27,6 +27,6 @@ namespace nuPickers.DataEditors.DotNetCheckBoxPicker
 
         [ConfigurationField("saveFormat", "Save Format",
             EmbeddedResource.EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
     }
 }

--- a/source/nuPickers/DataEditors/DotNetCheckBoxPicker/DotNetCheckBoxPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/DotNetCheckBoxPicker/DotNetCheckBoxPickerConfigurationEditor.cs
@@ -110,7 +110,9 @@ namespace nuPickers.DataEditors.DotNetCheckBoxPicker
 
             if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
             {
-                output.SaveFormat = saveFormatObj;
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
             }
 
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))

--- a/source/nuPickers/DataEditors/DotNetDropDownPicker/DotNetDropDownPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/DotNetDropDownPicker/DotNetDropDownPickerConfiguration.cs
@@ -8,7 +8,7 @@ namespace nuPickers.DataEditors.DotNetDropDownPicker
         public object DataSource { get; set; }
 
         [ConfigurationField("saveFormat", "Save Format", EmbeddedResource.EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
 
         [ConfigurationField("useLabel", "Include labels?", "boolean", Description = "")]
         public bool UseLabel { get; set; }

--- a/source/nuPickers/DataEditors/DotNetDropDownPicker/DotNetDropDownPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/DotNetDropDownPicker/DotNetDropDownPickerConfigurationEditor.cs
@@ -104,7 +104,7 @@ namespace nuPickers.DataEditors.DotNetDropDownPicker
             }
             if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
             {
-                var convertString = saveFormatObj.TryConvertTo<object>();
+                var convertString = saveFormatObj.TryConvertTo<string>();
                 if (convertString.Success)
                     output.SaveFormat = convertString.Result;
             }

--- a/source/nuPickers/DataEditors/DotNetPagedListPicker/DotNetPagedListPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/DotNetPagedListPicker/DotNetPagedListPickerConfigurationEditor.cs
@@ -112,6 +112,12 @@ namespace nuPickers.DataEditors.DotNetPagedListPicker
                 if (convertString.Success)
                     output.DataSource = convertString.Result;
             }
+            if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
+            {
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
+            }
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {
                 var convertString = customlabelObj.TryConvertTo<string>();

--- a/source/nuPickers/DataEditors/DotNetPrefetchListPicker/DotNetPrefetchListPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/DotNetPrefetchListPicker/DotNetPrefetchListPickerConfigurationEditor.cs
@@ -110,6 +110,12 @@ namespace nuPickers.DataEditors.DotNetPrefetchListPicker
                 if (convertString.Success)
                     output.DataSource = convertString.Result;
             }
+            if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
+            {
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
+            }
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {
                 var convertString = customlabelObj.TryConvertTo<string>();

--- a/source/nuPickers/DataEditors/DotNetRadioButtonPicker/DotNetRadioButtonPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/DotNetRadioButtonPicker/DotNetRadioButtonPickerConfigurationEditor.cs
@@ -107,6 +107,12 @@ namespace nuPickers.DataEditors.DotNetRadioButtonPicker
             {
                     output.DataSource = dataSourceObj;
             }
+            if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
+            {
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
+            }
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {
                 var convertString = customlabelObj.TryConvertTo<string>();

--- a/source/nuPickers/DataEditors/DotNetTypeaheadListPicker/DotNetTypeaheadListPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/DotNetTypeaheadListPicker/DotNetTypeaheadListPickerConfiguration.cs
@@ -22,6 +22,6 @@ namespace nuPickers.DataEditors.DotNetTypeaheadListPicker
         public object RelationMapping { get; set; }
 
         [ConfigurationField("saveFormat", "Save Format", EmbeddedResource.EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
     }
 }

--- a/source/nuPickers/DataEditors/DotNetTypeaheadListPicker/DotNetTypeaheadListPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/DotNetTypeaheadListPicker/DotNetTypeaheadListPickerConfigurationEditor.cs
@@ -110,6 +110,12 @@ namespace nuPickers.DataEditors.DotNetTypeaheadListPicker
                 if (convertString.Success)
                     output.DataSource = convertString.Result;
             }
+            if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
+            {
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
+            }
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {
                 var convertString = customlabelObj.TryConvertTo<string>();

--- a/source/nuPickers/DataEditors/EnumCheckBoxPicker/EnumCheckBoxPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/EnumCheckBoxPicker/EnumCheckBoxPickerConfiguration.cs
@@ -25,6 +25,6 @@ namespace nuPickers.DataEditors.EnumCheckBoxPicker
 
         [ConfigurationField("saveFormat", "Save Format",
             EmbeddedResource.EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
     }
 }

--- a/source/nuPickers/DataEditors/EnumCheckBoxPicker/EnumCheckBoxPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/EnumCheckBoxPicker/EnumCheckBoxPickerConfigurationEditor.cs
@@ -110,7 +110,9 @@ namespace nuPickers.DataEditors.EnumCheckBoxPicker
 
             if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
             {
-                output.SaveFormat = saveFormatObj;
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
             }
 
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))

--- a/source/nuPickers/DataEditors/EnumDropDownPicker/EnumDropDownPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/EnumDropDownPicker/EnumDropDownPickerConfiguration.cs
@@ -8,7 +8,7 @@ namespace nuPickers.DataEditors.EnumDropDownPicker
         public object DataSource { get; set; }
 
         [ConfigurationField("saveFormat", "Save Format", EmbeddedResource.EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
 
         [ConfigurationField("useLabel", "Include labels?", "boolean", Description = "")]
         public bool UseLabel { get; set; }

--- a/source/nuPickers/DataEditors/EnumDropDownPicker/EnumDropDownPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/EnumDropDownPicker/EnumDropDownPickerConfigurationEditor.cs
@@ -104,7 +104,7 @@ namespace nuPickers.DataEditors.EnumDropDownPicker
             }
             if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
             {
-                var convertString = saveFormatObj.TryConvertTo<object>();
+                var convertString = saveFormatObj.TryConvertTo<string>();
                 if (convertString.Success)
                     output.SaveFormat = convertString.Result;
             }

--- a/source/nuPickers/DataEditors/EnumPrefetchListPicker/EnumPrefetchListPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/EnumPrefetchListPicker/EnumPrefetchListPickerConfigurationEditor.cs
@@ -110,6 +110,12 @@ namespace nuPickers.DataEditors.EnumPrefetchListPicker
                 if (convertString.Success)
                     output.DataSource = convertString.Result;
             }
+            if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
+            {
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
+            }
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {
                 var convertString = customlabelObj.TryConvertTo<string>();

--- a/source/nuPickers/DataEditors/EnumRadioButtonPicker/EnumRadioButtonPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/EnumRadioButtonPicker/EnumRadioButtonPickerConfigurationEditor.cs
@@ -106,6 +106,12 @@ namespace nuPickers.DataEditors.EnumRadioButtonPicker
             {
                     output.DataSource = dataSourceObj;
             }
+            if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
+            {
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
+            }
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {
                 var convertString = customlabelObj.TryConvertTo<string>();

--- a/source/nuPickers/DataEditors/JsonCheckBoxPicker/JsonCheckBoxPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/JsonCheckBoxPicker/JsonCheckBoxPickerConfiguration.cs
@@ -20,7 +20,7 @@ namespace nuPickers.DataEditors.JsonCheckBoxPicker
         public object RelationMapping { get; set; }
 
         [ConfigurationField("saveFormat", "Save Format", EmbeddedResource.EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
         [ConfigurationField("useLabel", "Include labels?", "boolean", Description = "")]
         public bool UseLabel { get; set; }
     }

--- a/source/nuPickers/DataEditors/JsonCheckBoxPicker/JsonCheckBoxPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/JsonCheckBoxPicker/JsonCheckBoxPickerConfigurationEditor.cs
@@ -113,8 +113,11 @@ namespace nuPickers.DataEditors.JsonCheckBoxPicker
 
             if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
             {
-                    output.SaveFormat = saveFormatObj;
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
             }
+
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {
                 var convertString = customlabelObj.TryConvertTo<string>();

--- a/source/nuPickers/DataEditors/JsonDropDownPicker/JsonDropDownPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/JsonDropDownPicker/JsonDropDownPickerConfiguration.cs
@@ -14,7 +14,7 @@ namespace nuPickers.DataEditors.JsonDropDownPicker
 
         [ConfigurationField("saveFormat", "Save Format",
             EmbeddedResource.EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
 
         [ConfigurationField("useLabel", "Include labels?", "boolean", Description = "")]
         public bool UseLabel { get; set; }

--- a/source/nuPickers/DataEditors/JsonDropDownPicker/JsonDropDownPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/JsonDropDownPicker/JsonDropDownPickerConfigurationEditor.cs
@@ -106,10 +106,11 @@ namespace nuPickers.DataEditors.JsonDropDownPicker
 
             if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
             {
-                var convertString = saveFormatObj.TryConvertTo<object>();
+                var convertString = saveFormatObj.TryConvertTo<string>();
                 if (convertString.Success)
                     output.SaveFormat = convertString.Result;
             }
+
             if (editorValues.TryGetValue("relationMapping", out var relationMappingObj))
             {
                 var convertString = relationMappingObj.TryConvertTo<object>();

--- a/source/nuPickers/DataEditors/JsonPagedListPicker/JsonPagedListPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/JsonPagedListPicker/JsonPagedListPickerConfigurationEditor.cs
@@ -112,6 +112,12 @@ namespace nuPickers.DataEditors.JsonPagedListPicker
                 if (convertString.Success)
                     output.DataSource = convertString.Result;
             }
+            if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
+            {
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
+            }
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {
                 var convertString = customlabelObj.TryConvertTo<string>();

--- a/source/nuPickers/DataEditors/JsonPrefetchListPicker/JsonPrefetchListPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/JsonPrefetchListPicker/JsonPrefetchListPickerConfiguration.cs
@@ -29,6 +29,6 @@ namespace nuPickers.DataEditors.JsonPrefetchListPicker
 
         [ConfigurationField("saveFormat", "Save Format",
             EmbeddedResource.EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
     }
 }

--- a/source/nuPickers/DataEditors/JsonPrefetchListPicker/JsonPrefetchListPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/JsonPrefetchListPicker/JsonPrefetchListPickerConfigurationEditor.cs
@@ -110,6 +110,12 @@ namespace nuPickers.DataEditors.JsonPrefetchListPicker
                 if (convertString.Success)
                     output.DataSource = convertString.Result;
             }
+            if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
+            {
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
+            }
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {
                 var convertString = customlabelObj.TryConvertTo<string>();

--- a/source/nuPickers/DataEditors/JsonRadioButtonPicker/JsonRadioButtonPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/JsonRadioButtonPicker/JsonRadioButtonPickerConfigurationEditor.cs
@@ -109,6 +109,12 @@ namespace nuPickers.DataEditors.JsonRadioButtonPicker
             {
                     output.DataSource = dataSourceObj;
             }
+            if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
+            {
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
+            }
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {
                 var convertString = customlabelObj.TryConvertTo<string>();

--- a/source/nuPickers/DataEditors/JsonTypeaheadListPicker/JsonTypeaheadListPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/JsonTypeaheadListPicker/JsonTypeaheadListPickerConfiguration.cs
@@ -31,6 +31,6 @@ namespace nuPickers.DataEditors.JsonTypeaheadListPicker
 
         [ConfigurationField("saveFormat", "Save Format",
             EmbeddedResource.EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
     }
 }

--- a/source/nuPickers/DataEditors/JsonTypeaheadListPicker/JsonTypeaheadListPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/JsonTypeaheadListPicker/JsonTypeaheadListPickerConfigurationEditor.cs
@@ -113,6 +113,12 @@ namespace nuPickers.DataEditors.JsonTypeaheadListPicker
                 if (convertString.Success)
                     output.DataSource = convertString.Result;
             }
+            if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
+            {
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
+            }
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {
                 var convertString = customlabelObj.TryConvertTo<string>();

--- a/source/nuPickers/DataEditors/LuceneCheckBoxPicker/LuceneCheckBoxPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/LuceneCheckBoxPicker/LuceneCheckBoxPickerConfiguration.cs
@@ -31,6 +31,6 @@ namespace nuPickers.DataEditors.LuceneCheckBoxPicker
 
         [ConfigurationField("saveFormat", "Save Format",
             EmbeddedResource.EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
     }
 }

--- a/source/nuPickers/DataEditors/LuceneCheckBoxPicker/LuceneCheckBoxPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/LuceneCheckBoxPicker/LuceneCheckBoxPickerConfigurationEditor.cs
@@ -111,7 +111,9 @@ namespace nuPickers.DataEditors.LuceneCheckBoxPicker
 
             if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
             {
-                output.SaveFormat = saveFormatObj;
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
             }
 
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))

--- a/source/nuPickers/DataEditors/LuceneDropDownPicker/LuceneDropDownPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/LuceneDropDownPicker/LuceneDropDownPickerConfiguration.cs
@@ -11,7 +11,7 @@ namespace nuPickers.DataEditors.LuceneDropDownPicker
         public object RelationMapping { get; set; }
 
         [ConfigurationField("saveFormat", "Save Format", EmbeddedResource.EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
         [ConfigurationField("useLabel", "Include labels?", "boolean", Description = "")]
         public bool UseLabel { get; set; }
     }

--- a/source/nuPickers/DataEditors/LuceneDropDownPicker/LuceneDropDownPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/LuceneDropDownPicker/LuceneDropDownPickerConfigurationEditor.cs
@@ -106,10 +106,11 @@ namespace nuPickers.DataEditors.LuceneDropDownPicker
 
             if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
             {
-                var convertString = saveFormatObj.TryConvertTo<object>();
+                var convertString = saveFormatObj.TryConvertTo<string>();
                 if (convertString.Success)
                     output.SaveFormat = convertString.Result;
             }
+
             if (editorValues.TryGetValue("relationMapping", out var relationMappingObj))
             {
                 var convertString = relationMappingObj.TryConvertTo<object>();

--- a/source/nuPickers/DataEditors/LucenePagedListPicker/LucenePagedListPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/LucenePagedListPicker/LucenePagedListPickerConfiguration.cs
@@ -29,6 +29,6 @@ namespace nuPickers.DataEditors.LucenePagedListPicker
 
         [ConfigurationField("saveFormat", "Save Format",
             EmbeddedResource.EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
     }
 }

--- a/source/nuPickers/DataEditors/LucenePagedListPicker/LucenePagedListPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/LucenePagedListPicker/LucenePagedListPickerConfigurationEditor.cs
@@ -112,6 +112,12 @@ namespace nuPickers.DataEditors.LucenePagedListPicker
                 if (convertString.Success)
                     output.DataSource = convertString.Result;
             }
+            if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
+            {
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
+            }
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {
                 var convertString = customlabelObj.TryConvertTo<string>();

--- a/source/nuPickers/DataEditors/LucenePrefetchListPicker/LucenePrefetchListPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/LucenePrefetchListPicker/LucenePrefetchListPickerConfiguration.cs
@@ -32,6 +32,6 @@ namespace nuPickers.DataEditors.LucenePrefetchListPicker
 
         [ConfigurationField("saveFormat", "Save Format",
             EmbeddedResource.EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
     }
 }

--- a/source/nuPickers/DataEditors/LucenePrefetchListPicker/LucenePrefetchListPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/LucenePrefetchListPicker/LucenePrefetchListPickerConfigurationEditor.cs
@@ -112,6 +112,12 @@ namespace nuPickers.DataEditors.LucenePrefetchListPicker
                 if (convertString.Success)
                     output.DataSource = convertString.Result;
             }
+            if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
+            {
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
+            }
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {
                 var convertString = customlabelObj.TryConvertTo<string>();

--- a/source/nuPickers/DataEditors/LuceneRadioButtonPicker/LuceneRadioButtonPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/LuceneRadioButtonPicker/LuceneRadioButtonPickerConfiguration.cs
@@ -26,6 +26,6 @@
 
         [ConfigurationField("saveFormat", "Save Format",
             EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
     }
 }

--- a/source/nuPickers/DataEditors/LuceneRadioButtonPicker/LuceneRadioButtonPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/LuceneRadioButtonPicker/LuceneRadioButtonPickerConfigurationEditor.cs
@@ -103,7 +103,13 @@ namespace nuPickers.DataEditors.LuceneRadioButtonPicker
             }
             if (editorValues.TryGetValue("dataSource", out var dataSourceObj))
             {
-                    output.DataSource = dataSourceObj;
+                output.DataSource = dataSourceObj;
+            }
+            if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
+            {
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
             }
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {

--- a/source/nuPickers/DataEditors/LuceneTypeaheadPicker/LuceneTypeaheadListPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/LuceneTypeaheadPicker/LuceneTypeaheadListPickerConfiguration.cs
@@ -23,6 +23,6 @@
         public object RelationMapping { get; set; }
 
         [ConfigurationField("saveFormat", "Save Format", EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
     }
 }

--- a/source/nuPickers/DataEditors/LuceneTypeaheadPicker/LuceneTypeaheadListPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/LuceneTypeaheadPicker/LuceneTypeaheadListPickerConfigurationEditor.cs
@@ -113,6 +113,12 @@ namespace nuPickers.DataEditors.LuceneTypeaheadListPicker
                 if (convertString.Success)
                     output.DataSource = convertString.Result;
             }
+            if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
+            {
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
+            }
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {
                 var convertString = customlabelObj.TryConvertTo<string>();

--- a/source/nuPickers/DataEditors/SqlCheckBoxPicker/SqlCheckBoxPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/SqlCheckBoxPicker/SqlCheckBoxPickerConfiguration.cs
@@ -23,6 +23,6 @@
         public object RelationMapping { get; set; }
 
         [ConfigurationField("saveFormat", "Save Format", EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
     }
 }

--- a/source/nuPickers/DataEditors/SqlCheckBoxPicker/SqlCheckBoxPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/SqlCheckBoxPicker/SqlCheckBoxPickerConfigurationEditor.cs
@@ -111,7 +111,9 @@ namespace nuPickers.DataEditors.SqlCheckBoxPicker
 
             if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
             {
-                output.SaveFormat = saveFormatObj;
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
             }
 
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))

--- a/source/nuPickers/DataEditors/SqlDropDownPicker/SqlDropDownPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/SqlDropDownPicker/SqlDropDownPickerConfiguration.cs
@@ -14,7 +14,7 @@ namespace nuPickers.DataEditors.SqlDropDownPicker
         public object RelationMapping { get; set; }
 
         [ConfigurationField("saveFormat", "Save Format", EmbeddedResource.EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
 
     }
 }

--- a/source/nuPickers/DataEditors/SqlDropDownPicker/SqlDropDownPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/SqlDropDownPicker/SqlDropDownPickerConfigurationEditor.cs
@@ -106,7 +106,7 @@ namespace nuPickers.DataEditors.SqlDropDownPicker
             }
             if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
             {
-                var convertString = saveFormatObj.TryConvertTo<object>();
+                var convertString = saveFormatObj.TryConvertTo<string>();
                 if (convertString.Success)
                     output.SaveFormat = convertString.Result;
             }

--- a/source/nuPickers/DataEditors/SqlPagedListPicker/SqlPagedListPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/SqlPagedListPicker/SqlPagedListPickerConfiguration.cs
@@ -24,6 +24,6 @@
         public object RelationMapping { get; set; }
 
         [ConfigurationField("saveFormat", "Save Format", EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
     }
 }

--- a/source/nuPickers/DataEditors/SqlPagedListPicker/SqlPagedListPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/SqlPagedListPicker/SqlPagedListPickerConfigurationEditor.cs
@@ -112,6 +112,12 @@ namespace nuPickers.DataEditors.SqlPagedListPicker
                 if (convertString.Success)
                     output.DataSource = convertString.Result;
             }
+            if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
+            {
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
+            }
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {
                 var convertString = customlabelObj.TryConvertTo<string>();

--- a/source/nuPickers/DataEditors/SqlPrefetchListPicker/SqlPrefetchListPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/SqlPrefetchListPicker/SqlPrefetchListPickerConfiguration.cs
@@ -24,6 +24,6 @@
         public object RelationMapping { get; set; }
 
         [ConfigurationField("saveFormat", "Save Format", EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
     }
 }

--- a/source/nuPickers/DataEditors/SqlPrefetchListPicker/SqlPrefetchListPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/SqlPrefetchListPicker/SqlPrefetchListPickerConfigurationEditor.cs
@@ -113,6 +113,12 @@ namespace nuPickers.DataEditors.SqlPrefetchListPicker
                 if (convertString.Success)
                     output.DataSource = convertString.Result;
             }
+            if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
+            {
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
+            }
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {
                 var convertString = customlabelObj.TryConvertTo<string>();

--- a/source/nuPickers/DataEditors/SqlRadioButtonPicker/SqlRadioButtonPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/SqlRadioButtonPicker/SqlRadioButtonPickerConfiguration.cs
@@ -21,6 +21,6 @@
         public object RelationMapping { get; set; }
 
         [ConfigurationField("saveFormat", "Save Format", EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
     }
 }

--- a/source/nuPickers/DataEditors/SqlRadioButtonPicker/SqlRadioButtonPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/SqlRadioButtonPicker/SqlRadioButtonPickerConfigurationEditor.cs
@@ -105,6 +105,12 @@ namespace nuPickers.DataEditors.SqlRadioButtonPicker
             {
                     output.DataSource = dataSourceObj;
             }
+            if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
+            {
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
+            }
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {
                 var convertString = customlabelObj.TryConvertTo<string>();

--- a/source/nuPickers/DataEditors/SqlTypeaheadListPicker/SqlTypeaheadListPickerConfiguration.cs
+++ b/source/nuPickers/DataEditors/SqlTypeaheadListPicker/SqlTypeaheadListPickerConfiguration.cs
@@ -24,6 +24,6 @@
         public object RelationMapping { get; set; }
 
         [ConfigurationField("saveFormat", "Save Format", EmbeddedResource.ROOT_URL + "SaveFormat/SaveFormatConfig.html")]
-        public object SaveFormat { get; set; }
+        public string SaveFormat { get; set; }
     }
 }

--- a/source/nuPickers/DataEditors/SqlTypeaheadListPicker/SqlTypeaheadListPickerConfigurationEditor.cs
+++ b/source/nuPickers/DataEditors/SqlTypeaheadListPicker/SqlTypeaheadListPickerConfigurationEditor.cs
@@ -113,6 +113,12 @@ namespace nuPickers.DataEditors.SqlTypeaheadListPicker
                 if (convertString.Success)
                     output.DataSource = convertString.Result;
             }
+            if (editorValues.TryGetValue("saveFormat", out var saveFormatObj))
+            {
+                var convertString = saveFormatObj.TryConvertTo<string>();
+                if (convertString.Success)
+                    output.SaveFormat = convertString.Result;
+            }
             if (editorValues.TryGetValue("customLabel", out var customlabelObj))
             {
                 var convertString = customlabelObj.TryConvertTo<string>();


### PR DESCRIPTION
I tracked down the problem to the `FromConfigurationEditor` method in the `ConfigurationEditor` classes. Some of them were saving the saveFormat. Others had it omitted. Some were storing saveFormat as a string and others stored it as an object. As part of this commit, I added the code to store the saveFormat where it was missing and standardized all of the saveFormats to be a string.

I did most of my testing on the `nuPickers: Enum RadioButton Picker ` which was failing to store the saveFormat before I started. The `nuPickers: Enum CheckBox Picker` was working before I started and is still working on my local machine after these changes.