### PR TITLE
Fixed issue for nuPickers added to Membertypes

### DIFF
--- a/source/nuPickers/PickerPropertyValueConverter.cs
+++ b/source/nuPickers/PickerPropertyValueConverter.cs
@@ -113,11 +113,8 @@ namespace nuPickers
             if (assignedContentItem != null)
             {
                 contextId = assignedContentItem.Id;
-
-                if (assignedContentItem.Parent != null)
-                {
-                    parentId = assignedContentItem.Parent.Id;
-                }
+                var pathIds = assignedContentItem.Path?.Split(new char[] { ',' }).Select(id => Convert.ToInt32(id)).ToArray();
+                parentId = pathIds.Count() >= 2 ? pathIds[pathIds.Count() - 2] : parentId;
             }
 
             return new Picker(


### PR DESCRIPTION
When a nuPicker is added to a custum MemberType and an instcance of that membertype is loaded through use of the memberservice i.e. Umbraco.Web.Composing.Current.UmbracoHelper.Member(id), the PickerPropertyValueConverter throws an error on line: 117.

The check assignedContentItem.Parent != null appears not to be a valid check for IMember eventhough it's successfully cast to IPublishedContent, the fix works around the check by getting the parent id from the Path property.