### PR TITLE
Updated internal Picker constructor to set parentId to -1 if it is null

### DIFF
--- a/source/nuPickers/Picker.cs
+++ b/source/nuPickers/Picker.cs
@@ -101,7 +101,7 @@
         internal Picker(int contextId, int? parentId, string propertyAlias, int dataTypeId, string propertyEditorAlias, object savedValue)
         {
             this.ContextId = contextId;
-            this.ParentId = parentId == null ? -1 : (int)parentId;
+            this.ParentId = (parentId != null) ? (int)parentId : -1;
             this.PropertyAlias = propertyAlias;
             this.DataTypeId = dataTypeId;
             this.PropertyEditorAlias = propertyEditorAlias;

--- a/source/nuPickers/Picker.cs
+++ b/source/nuPickers/Picker.cs
@@ -98,10 +98,10 @@
         /// <param name="dataTypeId">the dataType id of this picker</param>
         /// <param name="propertyEditorAlias">the alias of the dataType</param>
         /// <param name="savedValue">the actual value saved</param>
-        internal Picker(int contextId, int parentId, string propertyAlias, int dataTypeId, string propertyEditorAlias, object savedValue)
+        internal Picker(int contextId, int? parentId, string propertyAlias, int dataTypeId, string propertyEditorAlias, object savedValue)
         {
             this.ContextId = contextId;
-            this.ParentId = parentId;
+            this.ParentId = parentId == null ? -1 : (int)parentId;
             this.PropertyAlias = propertyAlias;
             this.DataTypeId = dataTypeId;
             this.PropertyEditorAlias = propertyEditorAlias;


### PR DESCRIPTION
If an object does not for some reason have a parent, (like a Member object), then this allows the internal Picker constructor to set it to -1. This will allow any object referencing the Member type to pull the values without an error being thrown.